### PR TITLE
Fix email formatting and directory deletion

### DIFF
--- a/Path.py
+++ b/Path.py
@@ -81,12 +81,12 @@ class UserDirectories(Path):
 
     def delete_project_path(self) -> bool:
         paths = self.get_paths
+        deleted = False
         for path in paths:
             if os.path.exists(path):
                 shutil.rmtree(path)  # Удаляем директорию и все её содержимое
-                return True
-            else:
-                return False
+                deleted = True
+        return deleted
 
     def create_paths(self) -> bool:
         paths = self.get_paths

--- a/Support.py
+++ b/Support.py
@@ -45,14 +45,15 @@ class EmailSender:
 
     def send(self, app):
         with app.app_context():
-            msg_body = (f'Von: {request.form.get('firstName')} '
-                        f'{request.form.get('lastName')}\n'
-                        f'Tel.: {request.form.get('phone')}\n'
-                        f'E-mail: {request.form.get('email')}\n'
-                        f'Betreff: {request.form.get('inputGroupSelect01')}\n\n'
-                        f'Message:\n{request.form.get('message')}'
-                        "\n\n--------------------\nDiese E-Mail wurde von einem Kontaktformular von "
-                        "Baby, Babybauch & Kinder Fotografie (https://fotos-baby.ch) gesendet.")
+            msg_body = (
+                f"Von: {request.form.get('firstName')} {request.form.get('lastName')}\n"
+                f"Tel.: {request.form.get('phone')}\n"
+                f"E-mail: {request.form.get('email')}\n"
+                f"Betreff: {request.form.get('inputGroupSelect01')}\n\n"
+                f"Message:\n{request.form.get('message')}"
+                "\n\n--------------------\nDiese E-Mail wurde von einem Kontaktformular von "
+                "Baby, Babybauch & Kinder Fotografie (https://fotos-baby.ch) gesendet."
+            )
 
             self.__msg.body = msg_body
 


### PR DESCRIPTION
## Summary
- correct string quoting in `EmailSender.send`
- fix path deletion to remove all user directories

## Testing
- `pytest -q`
- `python -m py_compile Support.py Path.py`


------
https://chatgpt.com/codex/tasks/task_e_684137c588508333a47b7b8f6db79727